### PR TITLE
Remove pagy dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem "jsonapi-serializer"
 # Linter
 gem "standardrb"
 
-# Pagination
-gem "pagy_cursor"
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,10 +168,6 @@ GEM
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.4.3)
-    pagy_cursor (0.6.1)
-      activerecord (>= 5)
-      pagy (>= 6, < 7)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -321,7 +317,6 @@ DEPENDENCIES
   factory_bot_rails
   faker
   jsonapi-serializer
-  pagy_cursor
   puma (>= 5.0)
   rack-cors
   rails (~> 7.1.3)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,12 +3,6 @@ class Api::V1::UsersController < Api::V1::ApiController
   include CursorPaginatable
 
   def index
-    # @pagy, @users = pagy_cursor(
-    #   User.all,
-    #   order: {id: :asc},
-    #   after: params[:after],
-    #   items: params[:items] || User::PER_PAGE
-    # )
     @pagination, @users = paginate_with_cursor(
       User.all,
       by: :id,

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,27 +1,35 @@
 class Api::V1::UsersController < Api::V1::ApiController
   before_action :authenticate_user!
+  include CursorPaginatable
 
   def index
-    @pagy, @users = pagy_cursor(
+    # @pagy, @users = pagy_cursor(
+    #   User.all,
+    #   order: {id: :asc},
+    #   after: params[:after],
+    #   items: params[:items] || User::PER_PAGE
+    # )
+    @pagination, @users = paginate_with_cursor(
       User.all,
-      order: {id: :asc},
+      by: :id,
+      direction: :asc,
       after: params[:after],
       items: params[:items] || User::PER_PAGE
     )
 
     render json: {
       users: UserSerializer.new(@users).serializable_hash,
-      pagination: pagy_metadata(@pagy)
+      pagination: pagy_metadata(@pagination)
     }
   end
 
   private
 
-  def pagy_metadata(pagy)
+  def pagy_metadata(pagination)
     {
-      items: pagy.items,
-      position: pagy.position,
-      has_more: pagy.has_more?
+      items: pagination.items,
+      position: pagination.position,
+      has_more: pagination.has_more?
     }
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -23,6 +23,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     {
       items: pagination.items,
       position: pagination.position,
+      next_cursor: pagination.next_cursor,
       has_more: pagination.has_more?
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,5 @@
-require "pagy_cursor/pagy/extras/cursor"
-require "pagy_cursor/pagy/extras/uuid_cursor"
-
 class ApplicationController < ActionController::API
   include RackSessionFix
-  include Pagy::Backend
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/concerns/cursor_paginatable.rb
+++ b/app/controllers/concerns/cursor_paginatable.rb
@@ -1,0 +1,22 @@
+module CursorPaginatable
+  require "ostruct"
+
+  def paginate_with_cursor(relation, items: ::User::PER_PAGE, after: nil, by: :id, direction: :asc)
+
+    # Filter by cursor start value, if one is provided. If missing, we know we're on the first page.
+    relation = relation.where(by => after..) if after.present?
+
+    # Order the relation by the cursor field, and limit it to `items + 1` records.
+    # This is because we want to know if there are more records to load,
+    # and we need to know that before we actually load them.
+    relation = relation.order(by => direction).limit(items + 1).to_a
+
+    # If we don't have more records, we can just return the relation as is.
+    # If we do, we remove the last record because we only need its cursor value
+    # so we can use it to load the next page.
+    cursor = relation.pop.public_send(by) if relation.size > items
+    metadata = OpenStruct.new(items: items, position: after, next_cursor: cursor, has_more?: !cursor.nil?)
+    # Return the current results and the next cursor value.
+    [metadata, relation]
+  end
+end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,7 +1,0 @@
-# Optionally override some pagy default with your own in the pagy initializer
-Pagy::DEFAULT[:items] = 10        # items per page
-# Better user experience handled automatically
-require 'pagy/extras/overflow'
-require 'pagy/extras/metadata'
-
-Pagy::DEFAULT[:overflow] = :last_page

--- a/spec/concerns/cursor_paginatable_spec.rb
+++ b/spec/concerns/cursor_paginatable_spec.rb
@@ -1,0 +1,53 @@
+# spec/concerns/cursor_paginatable_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe CursorPaginatable do
+  let(:dummy_class) { Class.new { extend CursorPaginatable } }
+  let(:relation) { double('ActiveRecord::Relation') }
+
+  describe '#paginate_with_cursor' do
+    context 'when there are more records' do
+      let(:first_record) { double('Record', id: 1) }
+      let(:second_record) { double('Record', id: 2) }
+      let(:third_record) { double('Record', id: 3) }
+
+      before do
+        allow(relation).to receive(:where).and_return([second_record, third_record])
+        allow(relation).to receive(:order).and_return(relation)
+        allow(relation).to receive(:limit).and_return([first_record, second_record, third_record])
+      end
+
+      it 'returns metadata and relation without last record' do
+        metadata, result = dummy_class.paginate_with_cursor(relation, items: 2, after: nil, by: :id)
+
+        expect(metadata.items).to eq(2)
+        expect(metadata.position).to eq(nil)
+        expect(metadata.next_cursor).to eq(3)
+        expect(metadata.has_more?).to eq(true)
+        expect(result).to eq([first_record, second_record])
+      end
+    end
+
+    context 'when there are no more records' do
+      let(:first_record) { double('Record', id: 1) }
+      let(:second_record) { double('Record', id: 2) }
+
+      before do
+        allow(relation).to receive(:where).and_return([second_record])
+        allow(relation).to receive(:order).and_return(relation)
+        allow(relation).to receive(:limit).and_return([first_record, second_record])
+      end
+
+      it 'returns metadata and relation as is' do
+        metadata, result = dummy_class.paginate_with_cursor(relation, items: 2, after: nil, by: :id)
+
+        expect(metadata.items).to eq(2)
+        expect(metadata.position).to eq(nil)
+        expect(metadata.next_cursor).to eq(nil)
+        expect(metadata.has_more?).to eq(false)
+        expect(result).to eq([first_record, second_record])
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Api::V1::Users", type: :request do
     end
 
     it "returns pagination metadata" do
-      expect(json_response['pagination']).to include("items", "position", "has_more")
+      expect(json_response['pagination']).to include("items", "position", "has_more", "next_cursor")
     end
   end
 end


### PR DESCRIPTION
We can build a generic pagination approach without using an external dependency, in our case pagy.

### ToDo
- [x] Remove pagy dependency 
- [x] Roll out simple cursor-based pagination solution
- [x] Ensure test coverage